### PR TITLE
Helper function to convert int RGB to decimal RGB

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,13 @@ the required level:
   True
 
 .. _WCAG 2.0: http://www.w3.org/TR/WCAG20/
+
+If you want to use RGB values as integers, you can run:
+
+.. code-block:: python
+
+  >> import wcag_contrast_ratio as contrast
+  >> black = (0, 0, 0)
+  >> white = (255, 255, 255)
+  >> contrast.rgb_as_int(black, white)
+  21.0

--- a/wcag_contrast_ratio/contrast.py
+++ b/wcag_contrast_ratio/contrast.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-__all__ = ["rgb", "passes_AA", "passes_AAA"]
+__all__ = ["rgb", "passes_AA", "passes_AAA", "rgb_as_int"]
 
 
 def rgb(rgb1, rgb2):
@@ -48,3 +48,16 @@ def passes_AAA(contrast, large=False):
         return contrast >= 4.5
     else:
         return contrast >= 7.0
+
+
+def translate(value, value_min_range, value_max_range, min_range, max_range):
+    value_span = value_max_range - value_min_range
+    span = max_range - min_range
+    scaled = float(value - value_min_range) / float(value_span)
+    return min_range + (scaled * span)
+
+
+def rgb_as_int(rgb1, rgb2):
+    n_rgb1 = tuple([translate(c, 0, 255, 0, 1) for c in rgb1])
+    n_rgb2 = tuple([translate(c, 0, 255, 0, 1) for c in rgb2])
+    return rgb(n_rgb1, n_rgb2)


### PR DESCRIPTION
I had to implement this for a project because I was using integer values to map RGB colors. I created this helper function for my own usage, but maybe it can be part of the original code as well.