### PR TITLE
Update supported Pythons + use hypothesis instead of hypothesis-pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ deps =
   hypothesis
 
 commands =
-  {envbindir}/py.test test.py
+  py.test test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,pypy3
+envlist = py27,py37,py38,py39,py310,pypy,pypy3
 
 [testenv]
 deps =
   pytest
-  hypothesis-pytest
+  hypothesis
 
 commands =
   {envbindir}/py.test test.py


### PR DESCRIPTION
Hey,
I want to package your library for Fedora as it was recently started being used by Pygments and found out that `hypothesis-pytest` is no longer a separate package, it's included in `hypothesis` now. Also, I took the liberty to update Python's matrix to those which are currently supported by tox.